### PR TITLE
Fixed room related error in mac m1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     coroutines = '1.5.0'
     lifecycleVersion = '2.3.1'
     materialVersion = '1.3.0'
-    roomVersion = '2.3.0'
+    roomVersion = '2.4.0-alpha04'
     // testing
     junitVersion = '4.13.2'
     espressoVersion = '3.1.0'


### PR DESCRIPTION
Getting this error for the room version `2.3.0` specifically for m1 mac

`Caused by: java.lang.Exception: No native library is found for os.name=Mac and os.arch=aarch64. path=/org/sqlite/native/Mac/aarch64`

on upgrading the dependency to `2.4.0-alpha04` and above

so basically, fixed an issue with Room’s SQLite native library to support Apple’s M1 chips.

Reference StackOverflow post - [Link](https://stackoverflow.com/a/68912772/11493559)