### PR TITLE
ListAdapter DiffUtil fixed and NoteEntity updated to Data Class

### DIFF
--- a/app/src/main/java/com/akshatbhuhagal/mynotes/data/local/entities/NoteEntity.kt
+++ b/app/src/main/java/com/akshatbhuhagal/mynotes/data/local/entities/NoteEntity.kt
@@ -6,29 +6,30 @@ import androidx.room.PrimaryKey
 import java.io.Serializable
 
 @Entity(tableName = "Notes")
-class NoteEntity : Serializable {
+data class NoteEntity(
 
     @PrimaryKey(autoGenerate = true)
-    var id: Int = 0
+    var id: Int = 0,
 
     @ColumnInfo(name = "title")
-    var title: String? = null
+    var title: String? = null,
 
     @ColumnInfo(name = "date_time")
-    var dateTime: String? = null
+    var dateTime: String? = null,
 
     @ColumnInfo(name = "note_text")
-    var noteText: String? = null
+    var noteText: String? = null,
 
     @ColumnInfo(name = "img_path")
-    var imgPath: String? = null
+    var imgPath: String? = null,
     
     @ColumnInfo(name = "web_link")
-    var webLink: String? = null
+    var webLink: String? = null,
 
     @ColumnInfo(name = "color")
-    var color: String? = null
+    var color: String? = null,
 
+):Serializable{
     override fun toString(): String {
         return "$title : $dateTime"
     }

--- a/app/src/main/java/com/akshatbhuhagal/mynotes/presentation/home/NotesAdapter.kt
+++ b/app/src/main/java/com/akshatbhuhagal/mynotes/presentation/home/NotesAdapter.kt
@@ -20,11 +20,11 @@ class NotesAdapter : ListAdapter<NoteEntity, NotesAdapter.NotesViewHolder>(diffC
     companion object {
         val diffCallback = object : DiffUtil.ItemCallback<NoteEntity>() {
             override fun areItemsTheSame(oldItem: NoteEntity, newItem: NoteEntity): Boolean {
-                return oldItem == newItem
+                return oldItem.id == newItem.id
             }
 
             override fun areContentsTheSame(oldItem: NoteEntity, newItem: NoteEntity): Boolean {
-                return oldItem.id == newItem.id
+                return oldItem == newItem
             }
 
         }


### PR DESCRIPTION
### ListAdapter DiffUtil
- checking using `oldItem == newItem` in `areItemsTheSame()` is wrong as it would recreate viewHolder if any changes happen
-  checking using .id is correct as it wont recreate viewholder for the same item
- checking `areContentTheSame()` using `oldItem == newItem` is correct as it will only update the contents of the viewHolder if any details change and not recreate viewHolder

### NoteEntity being a class and not data class
- Classes that hold data should be data class
- Data class auto create the `equals()` method which is need for comparison in diffUtil