### PR TITLE
Remove kotlin synthetic from notes adapter

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -18,7 +18,9 @@
         <entry key="..\:/Users/Akshat/AndroidStudioProjects/MyNotes/app/src/main/res/menu/bottom_nav_menu.xml" value="0.36666666666666664" />
         <entry key="..\:/Users/Akshat/AndroidStudioProjects/MyNotes/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml" value="0.22135416666666666" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.19791666666666666" />
+        <entry key="app/src/main/res/layout/fragment_create_note.xml" value="0.29393115942028986" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.19791666666666666" />
+        <entry key="app/src/main/res/layout/item_rv_notes.xml" value="0.29393115942028986" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/com/akshatbhuhagal/mynotes/presentation/home/NotesAdapter.kt
+++ b/app/src/main/java/com/akshatbhuhagal/mynotes/presentation/home/NotesAdapter.kt
@@ -2,23 +2,70 @@ package com.akshatbhuhagal.mynotes.presentation.home
 
 import android.graphics.BitmapFactory
 import android.graphics.Color
-import android.provider.ContactsContract.CommonDataKinds.Note
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.akshatbhuhagal.mynotes.R
 import com.akshatbhuhagal.mynotes.data.local.entities.NoteEntity
-import com.akshatbhuhagal.mynotes.util.extensions.makeGone
-import com.akshatbhuhagal.mynotes.util.extensions.makeInvisible
-import com.akshatbhuhagal.mynotes.util.extensions.makeVisible
-import kotlinx.android.synthetic.main.item_rv_notes.view.*
+import com.akshatbhuhagal.mynotes.databinding.ItemRvNotesBinding
 
 class NotesAdapter : ListAdapter<NoteEntity, NotesAdapter.NotesViewHolder>(diffCallback) {
 
     private lateinit var listener: OnItemClickListener
+
+    inner class NotesViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val binding = ItemRvNotesBinding.bind(view)
+
+        fun bind(note: NoteEntity) {
+            with(binding) {
+                tvTitle.text = note.title
+                tvDesc.text = note.noteText
+                tvDateTime.text = note.dateTime
+
+                note.color?.let {
+                    cardView.setCardBackgroundColor(Color.parseColor(note.color))
+                }
+
+                if (note.imgPath.isNullOrEmpty().not()) {
+                    imgNote.setImageBitmap(BitmapFactory.decodeFile(note.imgPath))
+                    imgNote.visibility = View.VISIBLE
+                } else {
+                    imgNote.visibility = View.GONE
+                }
+
+                if (note.webLink.isNullOrEmpty().not()) {
+                    tvWebLink.text = note.webLink
+                    tvWebLink.visibility = View.VISIBLE
+                } else {
+                    tvWebLink.visibility = View.GONE
+                }
+
+                cardView.setOnClickListener {
+                    listener.onClicked(note.id)
+                }
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotesViewHolder {
+        val binding = ItemRvNotesBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return NotesViewHolder(binding.root)
+    }
+
+
+    override fun onBindViewHolder(holder: NotesViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    fun setOnClickListener(listener1: OnItemClickListener) {
+        listener = listener1
+    }
+
+    interface OnItemClickListener {
+        fun onClicked(notesId: Int)
+    }
 
     companion object {
         val diffCallback = object : DiffUtil.ItemCallback<NoteEntity>() {
@@ -29,56 +76,6 @@ class NotesAdapter : ListAdapter<NoteEntity, NotesAdapter.NotesViewHolder>(diffC
             override fun areContentsTheSame(oldItem: NoteEntity, newItem: NoteEntity): Boolean {
                 return oldItem == newItem
             }
-
         }
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotesViewHolder {
-        return NotesViewHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.item_rv_notes, parent, false)
-        )
-    }
-
-    override fun onBindViewHolder(holder: NotesViewHolder, position: Int) {
-
-        val item = getItem(position)
-
-        holder.itemView.tvTitle.text = item.title
-        holder.itemView.tvDesc.text = item.noteText
-        holder.itemView.tvDateTime.text = item.dateTime
-
-        if (item.color != null) {
-            holder.itemView.cardView.setCardBackgroundColor(Color.parseColor(item.color))
-        } else {
-            null
-        }
-
-        if (item.imgPath != null) {
-            holder.itemView.imgNote.setImageBitmap(BitmapFactory.decodeFile(item.imgPath))
-            holder.itemView.imgNote.makeVisible()
-        } else {
-            holder.itemView.imgNote.makeGone()
-        }
-
-        if (item.webLink != null) {
-            holder.itemView.tvWebLink.text = item.webLink
-            holder.itemView.tvWebLink.makeVisible()
-        } else {
-            holder.itemView.tvWebLink.makeGone()
-        }
-
-        holder.itemView.cardView.setOnClickListener {
-            listener.onClicked(item.id)
-        }
-    }
-
-    fun setOnClickListener(listener1: OnItemClickListener) {
-        listener = listener1
-    }
-
-    inner class NotesViewHolder(view: View) : RecyclerView.ViewHolder(view)
-
-    interface OnItemClickListener {
-        fun onClicked(notesId: Int)
     }
 }


### PR DESCRIPTION
Accessing view with kotlin synthetic is not safe way. I change NotesAdapter.kt and used view binding instead of synthetic. (Hacktoberfest)